### PR TITLE
Upgrade poison version

### DIFF
--- a/example/got/README.md
+++ b/example/got/README.md
@@ -7,7 +7,7 @@ To start your Phoenix app:
   * Install dependencies with `mix deps.get`
   * Create and migrate your database with `mix ecto.create && mix ecto.migrate`
   * Install Node.js dependencies with `npm install`
-  * Create `.env` file and export `OMISE_SECRET_KEY` in this file
+  * Create `.env` file and export `OMISE_SECRET_KEY` and `OMISE_PUBLIC_KEY` in this file
   * Start Phoenix endpoint with `source .env && mix phoenix.server`
 
 Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.

--- a/example/got/config/config.exs
+++ b/example/got/config/config.exs
@@ -24,7 +24,8 @@ config :logger, :console,
   metadata: [:request_id]
 
 config :omise,
-  secret_key: System.get_env("OMISE_SECRET_KEY")
+  secret_key: System.get_env("OMISE_SECRET_KEY"),
+  public_key: System.get_env("OMISE_PUBLIC_KEY")
 
 # Omise Api
 config :got,

--- a/example/got/lib/got/omise_test.ex
+++ b/example/got/lib/got/omise_test.ex
@@ -1,5 +1,8 @@
 defmodule GOT.OmiseTest do
+  def create_charge(card: "xxxx", amount: _, description: _) do
+    {:error, %Omise.Error{code: "failed_processing", message: "failed processing"}}
+  end
   def create_charge(_) do
-    {:ok, %Omise.Charge{}}
+    {:ok, %Omise.Charge{paid: true}}
   end
 end

--- a/example/got/lib/got/omise_test.ex
+++ b/example/got/lib/got/omise_test.ex
@@ -1,6 +1,6 @@
 defmodule GOT.OmiseTest do
   def create_charge(card: "xxxx", amount: _, description: _) do
-    {:error, %Omise.Error{code: "failed_processing", message: "failed processing"}}
+    {:error, %Omise.Error{code: "used_token", message: "token was already used"}}
   end
   def create_charge(_) do
     {:ok, %Omise.Charge{paid: true}}

--- a/example/got/test/controllers/page_controller_test.exs
+++ b/example/got/test/controllers/page_controller_test.exs
@@ -2,21 +2,33 @@ defmodule GOT.PageControllerTest do
   use GOT.ConnCase
 
   setup_all do
-    donate_params = [omise_token: "1234", donate: %{"house" => "house_stark", "amount" => "1000_00"}]
+    valid_donate_params =
+      [omise_token: "1234", donate: %{"house" => "house_stark", "amount" => "1000_00"}]
+    invalid_donate_params =
+      [omise_token: "xxxx", donate: %{"house" => "house_targaryen", "amount" => "500_00"}]
 
-    {:ok, donate_params: donate_params}
+    {:ok,
+      valid_donate_params: valid_donate_params,
+      invalid_donate_params: invalid_donate_params}
   end
 
-  test "GET /", %{conn: conn} do
+  test "index page", %{conn: conn} do
     conn = get conn, "/"
     assert html_response(conn, 200) =~ "Game of Thrones"
     assert html_response(conn, 200) =~ "Donate to the noble house you love."
   end
 
-  test "POST /donate", %{conn: conn, donate_params: donate_params} do
+  test "successful donation", %{conn: conn, valid_donate_params: valid_donate_params} do
     get conn, "/"
-    conn = post conn, "/donate", donate_params
+    conn = post conn, "/donate", valid_donate_params
     assert html_response(conn, 302)
     assert get_flash(conn, :info) =~ "Thanks for donating!"
+  end
+
+  test "failed donation", %{conn: conn, invalid_donate_params: invalid_donate_params} do
+    get conn, "/"
+    conn = post conn, "/donate", invalid_donate_params
+    assert html_response(conn, 302)
+    assert get_flash(conn, :error) =~ "failed processing"
   end
 end

--- a/example/got/test/controllers/page_controller_test.exs
+++ b/example/got/test/controllers/page_controller_test.exs
@@ -29,6 +29,6 @@ defmodule GOT.PageControllerTest do
     get conn, "/"
     conn = post conn, "/donate", invalid_donate_params
     assert html_response(conn, 302)
-    assert get_flash(conn, :error) =~ "failed processing"
+    assert get_flash(conn, :error) =~ "token was already used"
   end
 end

--- a/example/got/web/controllers/page_controller.ex
+++ b/example/got/web/controllers/page_controller.ex
@@ -11,17 +11,20 @@ defmodule GOT.PageController do
     params
     |> build_charge_params
     |> @omise_api.create_charge
-    |> case do
-      {:ok, charge} ->
-        cond do
-          charge.paid -> put_flash(conn, :info, "Thanks for donating!")
-          true        -> put_flash(conn, :error, charge.failure_message || "Something went wrong :(")
-        end
-      {:error, error} -> put_flash(conn, :error, error.message)
-    end
+    |> handle_response(conn)
     |> redirect(to: page_path(conn, :index))
   end
 
   defp build_charge_params(%{"omise_token" => card, "donate" => %{"house" => house, "amount" => amount}}),
     do: [card: card, amount: amount, description: "Donate to #{house}"]
+
+  defp handle_response({:ok, charge}, conn) do
+    cond do
+      charge.paid -> put_flash(conn, :info, "Thanks for donating!")
+      true        -> put_flash(conn, :error, charge.failure_message || "Something went wrong :(")
+    end
+  end
+  defp handle_response({:error, error}, conn) do
+    put_flash(conn, :error, error.message)
+  end
 end

--- a/example/got/web/templates/layout/app.html.eex
+++ b/example/got/web/templates/layout/app.html.eex
@@ -26,7 +26,7 @@
     <script src="<%= static_path(@conn, "/js/app.js") %>"></script>
     <script src="https://cdn.omise.co/omise.js"></script>
     <script>
-      Omise.setPublicKey("pkey_test_51n45m48358scj8jlv6");
+      Omise.setPublicKey("<%= omise_public_key %>");
     </script>
   </body>
 </html>

--- a/example/got/web/views/layout_view.ex
+++ b/example/got/web/views/layout_view.ex
@@ -1,3 +1,7 @@
 defmodule GOT.LayoutView do
   use GOT.Web, :view
+
+  def omise_public_key do
+    Application.get_env(:omise, :public_key)
+  end
 end

--- a/example/got/web/views/page_view.ex
+++ b/example/got/web/views/page_view.ex
@@ -7,11 +7,9 @@ defmodule GOT.PageView do
   end
 
   def noble_houses do
-    [
-      "House Stark": "house_stark",
-      "House Targaryen": "house_targaryen",
-      "House Lanister": "house_lanister"
-    ]
+    ["House Stark": "house_stark",
+     "House Targaryen": "house_targaryen",
+     "House Lanister": "house_lanister"]
   end
 
   def amounts do

--- a/lib/omise/util.ex
+++ b/lib/omise/util.ex
@@ -30,7 +30,9 @@ defmodule Omise.Util do
   defp normalize_response(data),                   do: {:ok, data}
 
   defp initialize_module(object) do
-    Module.concat(Omise, String.capitalize(object))
+    Omise
+    |> Module.concat(String.capitalize(object))
+    |> struct
   end
 
   def normalize_card_params(params) do

--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule Omise.Mixfile do
   defp deps do
     [
       {:httpoison, "~> 0.8.0"},
-      {:poison, "~> 1.5"},
+      {:poison, "~> 2.1.0"},
       {:earmark, "~> 0.2", only: :dev},
       {:ex_doc, "~> 0.11.1", only: :dev},
       {:mock, "~> 0.1.1", only: :test}

--- a/mix.lock
+++ b/mix.lock
@@ -8,5 +8,5 @@
   "meck": {:hex, :meck, "0.8.4"},
   "mimerl": {:hex, :mimerl, "1.0.2"},
   "mock": {:hex, :mock, "0.1.1"},
-  "poison": {:hex, :poison, "1.5.2"},
+  "poison": {:hex, :poison, "2.1.0"},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"}}


### PR DESCRIPTION
 - Update an example Phoenix app
 - Upgrade `Poison` library to the v2.1.0 in order to use with some app that required `Poison` > 2.0.0